### PR TITLE
setup-environment-internal: don't use 'repo rebase'

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -113,7 +113,6 @@ ln -sf "${MANIFESTS}" sources/
 
 repo sync
 repo start work --all
-repo rebase
 
 DISTRO=$(grep -w DISTRO conf/local.conf | grep -v '^#' | awk -F\" '{print $2}')
 export DISTRO_DIRNAME=`echo ${DISTRO} | sed 's#[.-]#_#g'`


### PR DESCRIPTION
'repo rebase' will update repos to tip of the branch ignoring locked
down revisions.

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>